### PR TITLE
server: add working Node 20 Dockerfile for Render Docker runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,12 @@ CI uses).
     `terraform.tfvars` (gitignored).
   - The API's CORS origin is read from `CLIENT_ORIGIN` (`server/app.ts`), set by
     terraform to the Vercel URL.
+  - **Render free tier:** the Render Terraform provider does NOT support free web
+    services (`starter` is its cheapest). For a free deploy, create the Render
+    service manually in the dashboard using the **Docker** runtime — `server/`
+    has a working `server/Dockerfile` (Node 20; runs `prisma db push` then
+    starts). Set env vars there: `DATABASE_URL`, `JWT_SECRET`, `CLIENT_ORIGIN`.
+    Leave Render's pre-deploy command empty (the image's CMD handles db push).
 
 ## Security note
 

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+npm-debug.log
+Dockerfile
+.dockerignore
+tests
+*.md

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,29 @@
+# Server (Express + Prisma) image for Render's Docker runtime.
+# Node 20 (the app/Prisma stack requires >=18; Node 16 is EOL).
+FROM node:20-slim
+
+WORKDIR /app
+
+# Prisma's query engine needs OpenSSL at build and runtime.
+RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies first for better layer caching.
+COPY package*.json ./
+RUN npm ci
+
+# Copy source (see .dockerignore — node_modules, dist and .env are excluded).
+COPY . .
+
+# Generate the Prisma client and compile TypeScript to dist/.
+RUN npx prisma generate && npm run build
+
+ENV NODE_ENV=production
+
+# Documentation only — Render injects PORT and the app reads process.env.PORT.
+EXPOSE 3000
+
+# Sync the schema to the database, then start the API.
+# (Leave Render's "Pre-Deploy Command" empty — this CMD handles db push.)
+CMD ["sh", "-c", "npx prisma db push && node dist/index.js"]


### PR DESCRIPTION
## What
Adds a working `server/Dockerfile` (Node 20) plus `.dockerignore` so the API can be deployed on Render's **Docker runtime** (the free tier can't be managed by the Render Terraform provider).

- `npm ci` → `prisma generate` → `tsc build`
- `CMD` runs `prisma db push` then starts the API (leave Render's pre-deploy command empty)
- `.dockerignore` keeps `node_modules`, `dist`, and `.env` out of the image

## Verified locally
- `docker build` succeeds (Prisma generate + tsc compile inside the image)
- Container serves `GET /` → "Welcome to the Task Manager API."
- `POST /api/users/register` writes to Postgres → `{"id":1,...}`

Also documents the free-tier Docker path in `CLAUDE.md`.