### PR TITLE
terraform: Path A — manage Neon + Vercel, Render manual on free

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,12 @@ CI uses).
 - **CD:** platform-native, declared in `terraform/`. Pushing to `main` makes
   **Vercel** (client) and **Render** (server) rebuild and deploy automatically;
   **Neon** hosts Postgres. GitHub Actions does CI only — it does not deploy.
-  - `terraform/deploy.tf` defines the Vercel project + Render web service with
-    `auto_deploy` and the GitHub link; env vars (incl. `NEXT_PUBLIC_API_URL`,
-    `DATABASE_URL`, `JWT_SECRET`, `CLIENT_ORIGIN`) are wired there.
+  - `terraform/deploy.tf` manages the Vercel project (always) and the Render web
+    service (only when `manage_render = true`, i.e. a paid plan). On the free
+    tier (`manage_render = false`, default) Render is created manually — see
+    `terraform/README.md`. `NEXT_PUBLIC_API_URL` is set on Vercel via
+    `var.api_url`; `CLIENT_ORIGIN`/`CLIENT_ORIGIN_REGEX` are set on Render
+    (dashboard on free, Terraform on paid).
   - Setup + apply steps: `terraform/README.md`. Requires a one-time GitHub app
     install in the Vercel and Render dashboards, then `terraform apply` with
     `terraform.tfvars` (gitignored).

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,73 +1,91 @@
 # Infrastructure (Terraform)
 
-Provisions the deployment for task-manager:
+Provisions task-manager deploy. **Path A (free)** — Terraform manages Neon +
+Vercel; Render runs on its **free tier**, which the Render Terraform provider
+cannot manage, so the Render service is created manually (once).
 
-- **Neon** — Postgres (`neon.tf`)
-- **Vercel** — Next.js client, git-native auto-deploy (`deploy.tf`)
-- **Render** — Express API, native Node runtime, git-native auto-deploy (`deploy.tf`)
+| Component | Hosting | Managed by |
+|-----------|---------|------------|
+| Postgres  | Neon    | Terraform (`neon.tf`) |
+| Client    | Vercel  | Terraform (`deploy.tf`) |
+| API       | Render (free, Docker) | **Manual** (dashboard) |
 
-Pushing to the production branch (`main`) makes Vercel and Render rebuild and
-deploy automatically — that's the CD. Terraform just declares the projects, env
-vars, and the GitHub link reproducibly.
+Once provisioned, **deploys are automatic**: push to `main` → Vercel and Render
+rebuild. Terraform is only for provisioning/config.
 
-## One-time manual prerequisites
+## Why Render is manual
 
-Terraform can declare the projects, but the **GitHub ↔ platform connection is an
-OAuth/app install that must be done once in each dashboard first**:
+Render's Terraform provider rejects the free plan: `no such plan free for service
+type web`. Only `starter`+ work in Terraform. So free tier = dashboard. To put
+Render under Terraform later, set `manage_render = true` on a paid plan.
 
-1. **Vercel**: log in, install the Vercel GitHub app, and grant it access to the
-   `task-manager` repo. Create an API token (Account Settings → Tokens).
-2. **Render**: log in, connect your GitHub account, grant access to the repo.
-   Create an API key (Account Settings → API Keys) and note your **owner ID**
-   (team `tea-…` or user `usr-…`).
-3. **Neon**: create an API key (Account Settings → API Keys). The project already
-   exists in state.
+## One-time manual steps
+
+1. **GitHub app installs** (Terraform can't do the OAuth):
+   - Vercel: install the Vercel GitHub app, grant access to `task-manager`.
+   - Render: connect GitHub, grant access to `task-manager`.
+2. **API tokens**: Vercel API token; Neon API key.
+3. **Render service** (free, Docker) — create manually:
+   - Runtime: **Docker**, Root Directory: `server`, Dockerfile Path: `./Dockerfile`
+   - Branch: `main`, Auto-Deploy: On, Pre-Deploy Command: *empty*
+   - Env vars: `DATABASE_URL` (Neon pooler string), `JWT_SECRET`, `env_type=production`,
+     `CLIENT_ORIGIN` (comma list incl. the Vercel URL),
+     `CLIENT_ORIGIN_REGEX` (`^https://task-manager-[a-z0-9-]+\.vercel\.app$`)
+   - Don't set `PORT` (Render injects it).
+   - Note the resulting URL (e.g. `https://task-manager-n1hi.onrender.com`).
 
 ## Configure
 
 ```bash
 cp terraform.tfvars.example terraform.tfvars
-# fill in tokens/keys/owner id  (terraform.tfvars is gitignored)
+# fill in: neon_api_key, vercel_api_token, api_url (the Render URL from step 3)
+# leave manage_render = false
 ```
 
 ## Apply
 
 ```bash
-terraform init      # downloads providers for your OS (the old linux-only
-                    # .terraform/ cache is gitignored and can be deleted)
+terraform init
 terraform fmt
 terraform validate
 terraform plan
 terraform apply
 ```
 
-Outputs after apply:
+Outputs: `api_url`, `database_url` (sensitive), `render_service_url`
+(`(unmanaged …)` on Path A).
 
-- `client_url`  → `https://<vercel_project_name>.vercel.app`
-- `server_url`  → `https://<render_service_name>.onrender.com`
-- `database_url` (sensitive)
+## URL wiring (manual, because hosts get random suffixes)
 
-## How the two sides find each other
+The platforms append a random suffix to hostnames, so URLs can't be derived from
+names. Set them by hand:
 
-URLs are derived deterministically from the project/service **names**, so there's
-no dependency cycle:
+- Vercel `NEXT_PUBLIC_API_URL` = Render URL → `var.api_url` (Terraform sets it).
+- Render `CLIENT_ORIGIN` = Vercel URL → set in the Render dashboard.
 
-- Vercel gets `NEXT_PUBLIC_API_URL = https://<render_service_name>.onrender.com`
-- Render gets `CLIENT_ORIGIN = https://<vercel_project_name>.vercel.app` (used by
-  the API's CORS config)
+They must point at each other or auth/CORS breaks.
 
-⚠️ If a chosen name is already taken, the platform appends a suffix and the
-derived URL will be wrong. Keep names unique, or set the env var to the real URL
-after the first apply.
+## Going full IaC later (Path B)
 
-## Notes / future work
+Upgrade Render to `starter`, then in `terraform.tfvars`:
 
-- **State is local.** `terraform.tfstate` is gitignored (it contains secrets).
-  For team use or CI, move to a remote backend (Terraform Cloud, S3+DynamoDB,
-  etc.). Never commit state.
-- **Schema changes** are applied via `prisma db push` in Render's pre-deploy
-  command. For production you'll eventually want real Prisma migrations
-  (`prisma migrate deploy`) instead.
-- **Render free/starter** services spin down when idle (cold starts) and the
-  region (`singapore`) differs from Neon (`ap-southeast-2`), adding some DB
-  latency. Adjust `render_plan` / `render_region` as needed.
+```hcl
+manage_render       = true
+render_api_key      = "rnd_…"
+render_owner_id     = "tea-…"
+jwt_secret          = "…"
+client_origins      = "https://<vercel-url>"
+client_origin_regex = "^https://task-manager-[a-z0-9-]+\\.vercel\\.app$"
+```
+
+`terraform apply` then creates/manages the Render web service (native Node
+runtime). Verify `render_web_service.server.url` resolves on the first plan.
+
+## Notes
+
+- **State is local** and gitignored (contains secrets). For team/CI use a remote
+  backend (Terraform Cloud, S3+DynamoDB). Never commit state.
+- Schema syncs via `prisma db push` (container CMD). Move to Prisma migrations
+  (`migrate deploy`) for production.
+- Render free spins down when idle (cold start); region `singapore` ≠ Neon
+  `ap-southeast-2` adds some DB latency.

--- a/terraform/deploy.tf
+++ b/terraform/deploy.tf
@@ -1,19 +1,21 @@
-# Client (Vercel) + server (Render) with git-native auto-deploy on push to the
-# production branch. The Neon database is defined in neon.tf.
+# Client (Vercel) + server (Render), git-native auto-deploy on push to the
+# production branch. Neon DB is in neon.tf.
 #
-# URLs are derived deterministically from the project/service names so the two
-# sides can reference each other without a dependency cycle. If a name is already
-# taken, the platform appends a suffix and these URLs will be wrong — keep names
-# unique, or override them after the first apply.
+# Render's FREE tier cannot be managed by the Terraform provider (no "free"
+# plan), so the Render service is OFF by default (manage_render = false) and
+# created manually in the dashboard — see terraform/README.md. Set
+# manage_render = true only on a paid plan (starter+).
+#
+# Real deploy URLs are passed in as variables (var.api_url, var.client_origins)
+# because the platforms append a random suffix to the hostname, so they can't be
+# derived from the names.
 
 locals {
-  repo_url   = "https://github.com/${var.github_repo}"
-  server_url = "https://${var.render_service_name}.onrender.com"
-  client_url = "https://${var.vercel_project_name}.vercel.app"
+  repo_url = "https://github.com/${var.github_repo}"
 }
 
 # ---------------------------------------------------------------------------
-# Client: Next.js on Vercel
+# Client: Next.js on Vercel (always managed)
 # ---------------------------------------------------------------------------
 
 resource "vercel_project" "client" {
@@ -30,17 +32,19 @@ resource "vercel_project" "client" {
   environment = [
     {
       key    = "NEXT_PUBLIC_API_URL"
-      value  = local.server_url
+      value  = var.api_url
       target = ["production", "preview"]
     },
   ]
 }
 
 # ---------------------------------------------------------------------------
-# Server: Express API on Render (native Node runtime, builds from repo)
+# Server: Express API on Render (paid plans only; manage_render = true)
 # ---------------------------------------------------------------------------
 
 resource "render_web_service" "server" {
+  count = var.manage_render ? 1 : 0
+
   name               = var.render_service_name
   plan               = var.render_plan
   region             = var.render_region
@@ -59,10 +63,11 @@ resource "render_web_service" "server" {
   }
 
   env_vars = {
-    DATABASE_URL = { value = neon_project.db.connection_uri_pooler }
-    JWT_SECRET   = { value = var.jwt_secret }
-    CLIENT_ORIGIN = { value = local.client_url }
-    NODE_VERSION = { value = "20" }
-    env_type     = { value = "production" }
+    DATABASE_URL        = { value = neon_project.db.connection_uri_pooler }
+    JWT_SECRET          = { value = var.jwt_secret }
+    CLIENT_ORIGIN       = { value = var.client_origins }
+    CLIENT_ORIGIN_REGEX = { value = var.client_origin_regex }
+    NODE_VERSION        = { value = "20" }
+    env_type            = { value = "production" }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,15 +1,15 @@
-output "client_url" {
-  value       = local.client_url
-  description = "Production URL of the Vercel client"
-}
-
-output "server_url" {
-  value       = local.server_url
-  description = "Public URL of the Render API"
+output "api_url" {
+  value       = var.api_url
+  description = "Render API base URL injected into the client"
 }
 
 output "database_url" {
   value       = neon_project.db.connection_uri_pooler
   description = "Pooled Neon connection string used by the API"
   sensitive   = true
+}
+
+output "render_service_url" {
+  value       = coalesce(one(render_web_service.server[*].url), "(unmanaged — created in Render dashboard)")
+  description = "Render service URL when managed by Terraform"
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,4 +1,8 @@
 # Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored (*.tfvars).
+#
+# Path A (free): Terraform manages Neon + Vercel. Render is created MANUALLY in
+# the dashboard (free tier). Leave manage_render = false and the render_* vars
+# blank.
 
 # --- Neon ---
 neon_api_key = "neon_xxx"
@@ -7,16 +11,23 @@ neon_api_key = "neon_xxx"
 github_repo = "Akash-Bhavsar/task-manager"
 
 # --- Vercel (client) ---
-vercel_api_token = "xxxxxxxx"
-# vercel_team_id = "team_xxx"        # only if the project is under a team
+vercel_api_token    = "xxxxxxxx"
+# vercel_team_id    = "team_xxx"      # only if the project is under a team
 vercel_project_name = "task-manager-client"
 
-# --- Render (server) ---
-render_api_key      = "rnd_xxxxxxxx"
-render_owner_id     = "tea-xxxxxxxx"   # or usr-xxxxxxxx; see `render owners` / API
-render_service_name = "task-manager-api"
-render_region       = "singapore"
-render_plan         = "starter"   # provider has no "free" tier — starter is cheapest
+# Real Render API URL -> injected as NEXT_PUBLIC_API_URL in the client.
+api_url = "https://task-manager-n1hi.onrender.com"
 
-# --- App secrets ---
-jwt_secret = "use-a-long-random-string"
+# --- Render (server) ---
+# Free tier: keep this false and create the service in the dashboard.
+manage_render = false
+
+# Only needed when manage_render = true (paid plan, starter+):
+# render_api_key      = "rnd_xxxxxxxx"
+# render_owner_id     = "tea-xxxxxxxx"
+# render_service_name = "task-manager-api"
+# render_region       = "singapore"
+# render_plan         = "starter"
+# jwt_secret          = "use-a-long-random-string"
+# client_origins      = "https://task-manager-xxxx.vercel.app"
+# client_origin_regex = "^https://task-manager-[a-z0-9-]+\\.vercel\\.app$"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,19 +54,46 @@ variable "vercel_project_name" {
   description = "Vercel project name. Production URL is https://<name>.vercel.app"
 }
 
+variable "api_url" {
+  type        = string
+  description = "Render API base URL, injected into the client as NEXT_PUBLIC_API_URL (e.g. https://task-manager-n1hi.onrender.com)"
+}
+
 # ---------------------------------------------------------------------------
-# Render (server)
+# Render (server). manage_render = false (default) => Render is created manually
+# in the dashboard (required for the free tier). render_* creds are only needed
+# when manage_render = true.
 # ---------------------------------------------------------------------------
+
+variable "manage_render" {
+  type        = bool
+  default     = false
+  description = "Manage the Render web service via Terraform. Requires a paid plan (starter+); free tier is unsupported by the provider."
+}
+
+variable "client_origins" {
+  type        = string
+  default     = ""
+  description = "Comma-separated CORS allowlist for the API (CLIENT_ORIGIN). Only used when manage_render = true."
+}
+
+variable "client_origin_regex" {
+  type        = string
+  default     = ""
+  description = "Regex of allowed origins for preview URLs (CLIENT_ORIGIN_REGEX). Only used when manage_render = true."
+}
 
 variable "render_api_key" {
   type        = string
   sensitive   = true
-  description = "Render API key (Account Settings > API Keys)"
+  default     = ""
+  description = "Render API key (Account Settings > API Keys). Needed only when manage_render = true."
 }
 
 variable "render_owner_id" {
   type        = string
-  description = "Render owner/team ID that owns the service"
+  default     = ""
+  description = "Render owner/team ID. Needed only when manage_render = true."
 }
 
 variable "render_service_name" {
@@ -99,5 +126,6 @@ variable "render_plan" {
 variable "jwt_secret" {
   type        = string
   sensitive   = true
-  description = "JWT signing secret for the API"
+  default     = ""
+  description = "JWT signing secret for the API. Only used when manage_render = true (otherwise set it in the Render dashboard)."
 }


### PR DESCRIPTION
Free tier can't be managed by the Render TF provider. Terraform now manages Neon + Vercel; Render is gated behind manage_render (default false) and created manually in the dashboard. Real URLs passed via api_url. README documents the manual Render Docker checklist and the Path B (paid) upgrade.